### PR TITLE
signy: restructure build system to accommodate esp-idf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,21 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-if(NOT CONFIG_SIGNY)
-    return()
+if(ESP_PLATFORM)
+  include (${COMPONENT_DIR}/esp-idf/signy/CMakeLists.txt)
+  return()
 endif()
-
-zephyr_include_directories(include)
-
-zephyr_library()
-
-zephyr_library_sources(
-    # SDK
-    src/base64.c
-    src/signy.c
-)
-
-zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
-zephyr_library_include_directories_ifdef(CONFIG_BUILD_WITH_TFM
-    $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/api_ns/interface/include
-)

--- a/README.md
+++ b/README.md
@@ -71,8 +71,7 @@ the project's `idf_component.yml`.
 ```yaml
 dependencies:
   signy:
-    path: components/signy
-    git: https://github.com/golioth/signy/esp-idf/signy
+    git: https://github.com/golioth/signy.git
 ```
 
 See the `esp-idf` [examples](./examples/esp-idf/) for more information.

--- a/esp-idf/signy/CMakeLists.txt
+++ b/esp-idf/signy/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set(signy_root ../../)
+set(signy_root ${CMAKE_CURRENT_LIST_DIR}/../../)
 set(signy_src ${signy_root}/src)
 
 idf_component_register(SRCS "${signy_src}/signy.c" "${signy_src}/base64.c"

--- a/esp-idf/signy/Kconfig
+++ b/esp-idf/signy/Kconfig
@@ -1,9 +1,0 @@
-# Copyright (C) 2025 Golioth, Inc.
-#
-# SPDX-License-Identifier: Apache-2.0
-
-menu "Signy Configuration"
-
-rsource '../../Kconfig'
-
-endmenu

--- a/examples/esp-idf/basic/main/idf_component.yml
+++ b/examples/esp-idf/basic/main/idf_component.yml
@@ -4,5 +4,4 @@
 
 dependencies:
   signy:
-    version: "0.1.0"
-    path: ../../../../esp-idf/signy
+    path: ../../../../

--- a/examples/esp-idf/ota/main/idf_component.yml
+++ b/examples/esp-idf/ota/main/idf_component.yml
@@ -4,5 +4,4 @@
 
 dependencies:
   signy:
-    version: "0.1.0"
-    path: ../../../../esp-idf/signy
+    path: ../../../../

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -4,6 +4,6 @@
 
 version: "0.1.0"
 description: Signed URLs for Embedded Devices
-url: https://github.com/golioth/signy/tree/main/esp-idf/signy
+url: https://github.com/golioth/signy
 dependencies:
   idf: ">=5"

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Copyright (c) 2025 Golioth, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if(NOT CONFIG_SIGNY)
+    return()
+endif()
+
+zephyr_include_directories("${ZEPHYR_CURRENT_MODULE_DIR}/include")
+
+zephyr_library()
+
+set(signy_src "${ZEPHYR_CURRENT_MODULE_DIR}/src")
+
+zephyr_library_sources(
+    # SDK
+    "${signy_src}/base64.c"
+    "${signy_src}/signy.c"
+)
+
+zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
+zephyr_library_include_directories_ifdef(CONFIG_BUILD_WITH_TFM
+    $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/api_ns/interface/include
+)

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -3,5 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 build:
-  cmake: .
   kconfig: Kconfig


### PR DESCRIPTION
Restructures build system to accommodate the intricacies of how the esp-idf component manager interprets component repositories. In order to fetch the entire repository when using as a git dependency, the idf_component.yml must reside at the root. We then opt to include the CMakeLists.txt from the component directory when ESP_PLATFORM is defined, and we move the Zephyr specific CMakeLists.txt to the module directory. The default CMakeLists.txt path for a Zephyr module is `zephyr/` so we opt to omit the field from the module.yml.