### PR TITLE
examples: esp-idf: add common Kconfig

### DIFF
--- a/examples/esp-idf/Kconfig
+++ b/examples/esp-idf/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2025 Golioth, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+config SIGNY_EXAMPLE_SIGNED_URL_MAX_SIZE
+  int "Max size for signed URL"
+  default 1024
+  help
+    Maximum size for signed URL.
+
+config SIGNY_EXAMPLE_BASE_URL
+  string "Base URL to be signed"
+  default "https://gw.golioth.io/.u/c/main@1.0.0"
+  help
+    Base URL to be signed using signy.
+
+config SIGNY_EXAMPLE_CURRENT_UNIX_TIMESTAMP
+  int "Current Unix timestamp"
+  default 0
+  help
+    Timestamp used to set the current time at boot.
+

--- a/examples/esp-idf/Kconfig
+++ b/examples/esp-idf/Kconfig
@@ -10,7 +10,7 @@ config SIGNY_EXAMPLE_SIGNED_URL_MAX_SIZE
 
 config SIGNY_EXAMPLE_BASE_URL
   string "Base URL to be signed"
-  default "https://gw.golioth.io/.u/c/main@1.0.0"
+  default "https://gw.golioth.io/.u/c/signy@1.0.0"
   help
     Base URL to be signed using signy.
 

--- a/examples/zephyr/basic/README.md
+++ b/examples/zephyr/basic/README.md
@@ -105,7 +105,7 @@ example, if using `signy` with Golioth, a signed URL can be generated for the
 `main@1.0.0` OTA artifact in your project using the following command.
 
 ```
-signy sign https://gw.golioth.io/.u/c/main@1.0.0
+signy sign https://gw.golioth.io/.u/c/signy@1.0.0
 ```
 
 The generated signed URL will be valid for the duration specified in


### PR DESCRIPTION
Adds a common Kconfig that is used across esp-idf examples.

(This was missed in #11)