### PR TITLE
release: prep signy for the v0.2.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ included in any Zephyr project by adding the following to the project's
 ```yaml
 - name: signy
   path: modules/lib/signy
-  revision: main
+  revision: v0.2.0
   url: https://github.com/golioth/signy.git
 ```
 
@@ -71,6 +71,7 @@ the project's `idf_component.yml`.
 ```yaml
 dependencies:
   signy:
+    version: v0.2.0
     git: https://github.com/golioth/signy.git
 ```
 

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-version: "0.1.0"
+version: "v0.2.0"
 description: Signed URLs for Embedded Devices
 url: https://github.com/golioth/signy
 dependencies:


### PR DESCRIPTION
Updates version references for the v0.2.0 release.

Signed-off-by: Daniel Mangum <georgedanielmangum@gmail.com>

Needs rebase on #14 