### PR TITLE
esp-idf: remove leading v from component version

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-version: "v0.2.0"
+version: "0.2.0"
 description: Signed URLs for Embedded Devices
 url: https://github.com/golioth/signy
 dependencies:


### PR DESCRIPTION
The esp-idf component manager does not support component manifest files with a leading v in the semantic version. A dependency can be specified using a git version tag with a leading v, but the version in the manifest must comply to their versioning requirements.